### PR TITLE
Specify valid target for node-sass peer dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "rsvp": "^3.0.6"
   },
   "peerDependencies": {
-    "node-sass": "^3.0.0"
+    "node-sass": "3.0.0-beta.5"
   }
 }


### PR DESCRIPTION
By specifying node-sass with a caret `^3.0.0` this package fails to install as a peer dependency. I don't think npm recognizes 3.0.0-beta\* as being ^3.0.0. Here's what I saw:

```
$ npm i
npm ERR! Darwin 14.1.0
npm ERR! argv "node" "/Users/danielpazsoldan/.nvm/v0.10.33/bin/npm" "i"
npm ERR! node v0.10.33
npm ERR! npm  v2.5.1
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: node-sass@'>=3.0.0 <4.0.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.9.4-rc1","0.2.0","0.2.1","0.2.2","0.2.3","0.2.4","0.2.5","0.2.6","0.3.0","0.4.0","0.4.1","0.4.2","0.4.3","0.4.4","0.5.0","0.5.1","0.5.2","0.5.3","0.5.4","0.6.0","0.6.1","0.6.2","0.6.3","0.6.4","0.6.5","0.6.6","0.6.7","0.7.0-alpha","0.7.0","0.8.0","0.8.1","0.8.2","0.8.3","0.8.4","0.8.5","0.8.6","0.9.0","0.9.1","0.9.2","0.9.3","0.9.4-rc1","0.9.4","0.9.5-rc1","0.9.5","0.9.6","1.0.0","1.0.1","1.0.2-alpha","1.0.2","1.0.3","1.1.0","1.1.1","1.1.2","1.1.3","1.1.4","1.2.0","1.2.1","1.2.2","1.2.3","2.0.0-beta","2.0.0","2.0.1","3.0.0-alpha.0","3.0.0-beta.2","3.0.0-beta.3","3.0.0-beta.4","2.1.0","2.1.1","3.0.0-beta.5"]
```

Specifying the exact 3.0.0-beta version seems to fix the problem. I wasn't sure which version you wanted so I just picked the latest 3.0.0-beta.5.
