### PR TITLE
Upgraded to node-sass 3.0.0-beta.7 and related doc changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Upgrade to node-sass 3.0.0-beta.7
+* Remove `imagePath` from options documentation. Support for this was removed from node-sass/libsass
+* Add `functions` to options documentation. See https://github.com/sass/node-sass#functions--v300---experimental (Note that if losing `image-url` from sass is a problem for you, you can now implement it yourself as a custom function)
+
 # 0.6.4
 
 * Upgrade to node-sass 3.0.0-beta.5

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var outputTree = compileSass(inputTrees, inputFile, outputFile, options);
 * **`outputFile`**: Relative path of the output CSS file.
 
 * **`options`**: A hash of options for libsass. Supported options are:
-  `imagePath`, `indentedSyntax`, `omitSourceMapUrl`, `outputStyle`, `precision`,
+  `functions`, `indentedSyntax`, `omitSourceMapUrl`, `outputStyle`, `precision`,
   `sourceComments`, `sourceMap`, `sourceMapEmbed`, and `sourceMapContents`.
 
 ### Example

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function SassCompiler (inputTrees, inputFile, outputFile, options) {
   this.outputFile = outputFile
   options = options || {}
   this.sassOptions = {
-    imagePath: options.imagePath,
+    functions: options.functions,
     indentedSyntax: options.indentedSyntax,
     omitSourceMapUrl: options.omitSourceMapUrl,
     outputStyle: options.outputStyle,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "rsvp": "^3.0.6"
   },
   "peerDependencies": {
-    "node-sass": "^3.0.0-beta.2"
+    "node-sass": "^3.0.0-beta.7"
   }
 }


### PR DESCRIPTION
- Removed `imagePath` from options documentation. Support for this was removed from libsass
- Added `functions` to options documentation. See https://github.com/sass/node-sass#functions--v300---experimental

My ultimate goal here is to allow ember-cli-sass to support custom functions. 
