### PR TITLE
Added importer option to SASS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var outputTree = compileSass(inputTrees, inputFile, outputFile, options);
 * **`outputFile`**: Relative path of the output CSS file.
 
 * **`options`**: A hash of options for libsass. Supported options are:
-  `functions`, `indentedSyntax`, `omitSourceMapUrl`, `outputStyle`, `precision`,
+  `functions`, `importer`, `indentedSyntax`, `omitSourceMapUrl`, `outputStyle`, `precision`,
   `sourceComments`, `sourceMap`, `sourceMapEmbed`, and `sourceMapContents`.
 
 * **`nodeSass`**: Allows a different version of [node-sass](https://www.npmjs.com/package/node-sass) to be used.

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function SassCompiler (inputNodes, inputFile, outputFile, options) {
 
   this.sassOptions = {
     functions: options.functions,
+    importer: options.importer,
     indentedSyntax: options.indentedSyntax,
     omitSourceMapUrl: options.omitSourceMapUrl,
     outputStyle: options.outputStyle,


### PR DESCRIPTION
I want to use [fetch/node-sass-css-importer](https://github.com/fetch/node-sass-css-importer) in my build.

This PR just passes a new option `importer` to sass.
