### PR TITLE
Builds failed with node-sass 3.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^2.0.1",
     "include-path-searcher": "^0.1.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.3.1",
+    "node-sass": "3.3.3",
     "object-assign": "^2.0.0",
     "rsvp": "^3.0.6"
   },


### PR DESCRIPTION
I'm fairly confident you're not going to want to merge this, but 3.3.3 is the most recent version of node-sass I could get to work with my app. Failing travis build log: https://travis-ci.org/SirZach/foosball/builds/87757888
