### PR TITLE
Lock libsass to the last known good version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^2.0.1",
     "include-path-searcher": "^0.1.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.3.1",
+    "node-sass": "~3.3.1",
     "object-assign": "^2.0.0",
     "rsvp": "^3.0.6"
   },


### PR DESCRIPTION
The latest libsass has some problems with interpolation, etc. For example, the [neat](https://github.com/thoughtbot/neat) package cannot be compiled anymore.
This PR locks the libsass to the latest known good version.
