### PR TITLE
Allow configuration of custom importer

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function SassCompiler (inputNodes, inputFile, outputFile, options) {
   this.renderSass = rsvp.denodeify(sass.render);
 
   this.sassOptions = {
+    importer: options.importer,
     functions: options.functions,
     indentedSyntax: options.indentedSyntax,
     omitSourceMapUrl: options.omitSourceMapUrl,


### PR DESCRIPTION
In Ember Community slack, a user was asking about globbing. This apparently requires the `importer` option to be passed to `sass.render`.

This PR adds `options.importer` to be specified to allow this configuration.
