### PR TITLE
Pin node-sass to revision number instead of the entire 3.x.y series

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^2.0.1",
     "include-path-searcher": "^0.1.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.4.1",
+    "node-sass": "~3.4.1",
     "object-assign": "^2.0.0",
     "rsvp": "^3.0.6"
   },


### PR DESCRIPTION
I'm seeing failures with `node-sass@3.5.1` dependency. Pinning to the `3.4.x` series should fix the problem. Details at https://github.com/sass/node-sass/issues/1455
