### PR TITLE
Upgrade to node-sass 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^2.0.1",
     "include-path-searcher": "^0.1.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.4.1",
+    "node-sass": "^3.8.0",
     "object-assign": "^2.0.0",
     "rsvp": "^3.0.6"
   },


### PR DESCRIPTION
node-sass 3.6.0 brings in libsass 3.3.6 which fixes a seg fault some users were experiencing.
