### PR TITLE
Make compatible with ember twiddle (node-sass@4.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "broccoli-caching-writer": "^3.0.3",
     "include-path-searcher": "^0.1.0",
     "mkdirp": "^0.3.5",
-    "node-sass": "^3.8.0",
+    "node-sass": "^4.1.0",
     "object-assign": "^2.0.0",
     "rsvp": "^3.0.6"
   },


### PR DESCRIPTION
The latest version of node-sass@4.1.0 can be compiled on Alpine linux - which allows addons with ember-cli-sass dependency to be included in ember twiddle.