### PR TITLE
Made options object optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var outputTree = compileSass(inputTrees, inputFile, outputFile, options);
 
 * **`outputFile`**: Relative path of the output CSS file.
 
-* **`options`**: A hash of options for libsass and caching writer. 
+* **`options`**: An optional hash of options for libsass and caching writer. 
   * Supported options for libsass are:
   `functions`, `indentedSyntax`, `omitSourceMapUrl`, `outputStyle`, `precision`,
   `sourceComments`, `sourceMap`, `sourceMapEmbed`, and `sourceMapContents`.
@@ -50,7 +50,7 @@ var appCss = compileSass(['styles', 'vendor'], 'myapp/app.scss', 'assets/app.css
 
 ## Choosing the version of node-sass
 
-You can specify which version of node-sass to use with the [`nodeSass` option](https://github.com/aexmachina/broccoli-sass-source-maps#usage). 
+You can specify which version of node-sass to use with the [`nodeSass` option](https://github.com/aexmachina/broccoli-sass-source-maps#usage).
 
 Add the version that you want to use to _your_ package.json and then provide that version of the module using the `nodeSass` option:
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ function SassCompiler (inputNodes, inputFile, outputFile, options) {
   if (!(this instanceof SassCompiler)) { return new SassCompiler(inputNodes, inputFile, outputFile, options); }
   if (!Array.isArray(inputNodes)) { throw new Error('Expected array for first argument - did you mean [tree] instead of tree?'); }
 
+  options = options || {};
+
   CachingWriter.call(this, inputNodes, {
     annotation: options.annotation,
     cacheInclude: options.cacheInclude,
@@ -25,7 +27,6 @@ function SassCompiler (inputNodes, inputFile, outputFile, options) {
 
   this.inputFile = inputFile;
   this.outputFile = outputFile;
-  options = options || {};
   this.options = {
     nodeSass: options.nodeSass
   };


### PR DESCRIPTION
It seems that the intention was already for the options object to
be optional, but the fact that we pass a few properties of the options
object to the CachingWriter constructor before assigning a default
value of an empty object to it meant that we relied on it being an object.